### PR TITLE
Uses `~/.bash_profile` instead of `~/.bashrc`.

### DIFF
--- a/mac
+++ b/mac
@@ -11,17 +11,17 @@ fancy_echo() {
   printf "\n$fmt\n" "$@"
 }
 
-append_to_bashrc() {
-  local text="$1" bashrc
+append_to_bash_profile() {
+  local text="$1" bash_profile
   local skip_new_line="${2:-0}"
 
-  bashrc="$HOME/.bashrc"
+  bash_profile="$HOME/.bash_profile"
 
-  if ! grep -Fqs "$text" "$bashrc"; then
+  if ! grep -Fqs "$text" "$bash_profile"; then
     if [ "$skip_new_line" -eq 1 ]; then
-      printf "%s\n" "$text" >> "$bashrc"
+      printf "%s\n" "$text" >> "$bash_profile"
     else
-      printf "\n%s\n" "$text" >> "$bashrc"
+      printf "\n%s\n" "$text" >> "$bash_profile"
     fi
   fi
 }
@@ -35,12 +35,12 @@ if [ ! -d "$HOME/.bin/" ]; then
   mkdir "$HOME/.bin"
 fi
 
-if [ ! -f "$HOME/.bashrc" ]; then
-  touch "$HOME/.bashrc"
+if [ ! -f "$HOME/.bash_profile" ]; then
+  touch "$HOME/.bash_profile"
 fi
 
 # shellcheck disable=SC2016
-append_to_bashrc 'export PATH="$HOME/.bin:$PATH"'
+append_to_bash_profile 'export PATH="$HOME/.bin:$PATH"'
 
 HOMEBREW_PREFIX="/usr/local"
 
@@ -90,10 +90,10 @@ if ! command -v brew >/dev/null; then
     curl -fsS \
       'https://raw.githubusercontent.com/Homebrew/install/master/install' | ruby
 
-    append_to_bashrc '# recommended by brew doctor'
+    append_to_bash_profile '# recommended by brew doctor'
 
     # shellcheck disable=SC2016
-    append_to_bashrc 'export PATH="/usr/local/bin:$PATH"' 1
+    append_to_bash_profile 'export PATH="/usr/local/bin:$PATH"' 1
 
     export PATH="/usr/local/bin:$PATH"
 fi
@@ -152,8 +152,8 @@ fi
 fancy_echo "Configuring asdf version manager..."
 if [ ! -d "$HOME/.asdf" ]; then
   git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.4.2
-  append_to_bashrc "source $HOME/.asdf/asdf.sh" 1
-  append_to_bashrc "source $HOME/.asdf/completions/asdf.bash" 1
+  append_to_bash_profile "source $HOME/.asdf/asdf.sh" 1
+  append_to_bash_profile "source $HOME/.asdf/completions/asdf.bash" 1
 fi
 
 install_asdf_plugin() {


### PR DESCRIPTION
Mac terminal uses `~/.bash_profile` instead of `~/.bashrc`. There are really two solutions:
1. We source `~/.bashrc` in `~/.bash_profile`.
1. We just append to `~/.bash_profile` instead of `~/.bashrc`.

I went with the later solution simply because most installation instructions I've seen use `~/.bash_profile`. If someone has a better reason to use the first, then we can switch it.