### PR TITLE
Installs `cmake` using Homebrew.

### DIFF
--- a/mac
+++ b/mac
@@ -141,6 +141,10 @@ cask "gpg-suite"
 # Databases
 brew "postgresql@9.6", restart_service: :changed
 brew "redis", restart_service: :changed
+
+# App-specific requirements
+## Edge
+brew "cmake"
 EOF
 
 if brew list | grep --silent "qt@5.5"; then


### PR DESCRIPTION
I don't remember what for, but I had to run `brew install cmake` when setting up Edge.

Since this is a brew install, it seemed like it belonged in our laptop script. However, it's an issue specific to Edge (as far as I know), so maybe it makes more sense for this to be part of Edge's setup script?