### PR TITLE
Adds a line to change the default merge conflict style 

### DIFF
--- a/mac
+++ b/mac
@@ -114,6 +114,8 @@ tap "caskroom/cask"
 # Unix
 brew "universal-ctags", args: ["HEAD"]
 brew "git"
+# git customization
+git config --global merge.conflictstyle diff3
 brew "openssl"
 brew "rcm"
 brew "reattach-to-user-namespace"


### PR DESCRIPTION
I found that this diff style for merge conflicts was helpful. It shows the ancestor branch in addition to the merge conflict diffs.

More documentation here: https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging

![unnamed](https://user-images.githubusercontent.com/8131064/45961849-825baa80-bfed-11e8-853c-c9d55f2d3b87.png)
