### PR TITLE
Adds 'zlib' as a dependency for Push (really, Python)

### DIFF
--- a/mac
+++ b/mac
@@ -146,6 +146,9 @@ brew "redis", restart_service: :changed
 # App-specific requirements
 ## Edge
 brew "cmake"
+
+## Push (for Python)
+brew "zlib"
 EOF
 
 if brew list | grep --silent "qt@5.5"; then
@@ -157,6 +160,11 @@ fi
 if [ "$(which psql)" == "" ] ; then
   fancy_echo "'psql' not found in PATH, attempting to add it..."
   append_to_bash_profile 'export PATH="/usr/local/opt/postgresql@9.6/bin:$PATH"'
+fi
+
+if [ "$(echo $CPPFLAGS)" == "" ] ; then
+  fancy_echo "Your 'CPPFLAGS' env. variable (required for zlib) is not set. Adding to '~/.bash_profile'..."
+  append_to_bash_profile 'export CPPFLAGS="-I/usr/local/opt/zlib/include"'
 fi
 
 fancy_echo "Configuring asdf version manager..."


### PR DESCRIPTION
Python is required to run Push.

Installing python with `asdf` failed for me. Installing 'zlib' through homebrew and following the instruction [here](https://github.com/pyenv/pyenv/wiki/common-build-problems#build-failed-error-the-python-zlib-extension-was-not-compiled-missing-the-zlib) fixed it.

## Checklist
- [x] I've reviewed the entire diff
- [x] all changes are essential to what we're trying to achieve
- [x] ~relevant tests added~ none
- [x] ~all tests passing~ none
- [x] ~relevant metrics added~ none
- [x] ~no style issues~ no style guide
- [x] ~documentation added/updated as necessary (using [tags](https://docs.google.com/document/d/1OFrkFQHIA7ucvHyE5EqAnkPuWwGwQ04CYFD0VpF7Xhs/edit) on Drive should make this easier)~ none needed
